### PR TITLE
allow Integer, Double, Long when setting event attribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.forter</groupId>
     <artifactId>riemann-storm-monitor</artifactId>
     <packaging>jar</packaging>
-    <version>0.10.37.4</version>
+    <version>0.10.37.5</version>
     <properties>
         <storm.version>0.10.0</storm.version>
         <storm.topology>com.forter.BrainTopology</storm.topology>

--- a/src/main/java/com/forter/monitoring/events/RiemannEvent.java
+++ b/src/main/java/com/forter/monitoring/events/RiemannEvent.java
@@ -93,6 +93,18 @@ public class RiemannEvent {
         return this;
     }
 
+    public RiemannEvent attribute(String key, Integer value) {
+        return attribute(key, Integer.toString(value));
+    }
+
+    public RiemannEvent attribute(String key, Long value) {
+        return attribute(key, Long.toString(value));
+    }
+
+    public RiemannEvent attribute(String key, Double value) {
+        return attribute(key, Double.toString(value));
+    }
+
     public RiemannEvent attributes(Map<String, String> attributes) {
         if(this.customAttributes == null) {
             this.customAttributes = attributes;


### PR DESCRIPTION
to replace calls like this: `.attribute("attributeOfTypeLog", Long.toString(attrLongValue))` 
with  `.attribute("attributeOfTypeLog", attrLongValue)`